### PR TITLE
Code scanning improvements

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/MemberAutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/MemberAutoDataBaseAttributeTests.cs
@@ -28,7 +28,7 @@
             { null, MemberType.Name },
         };
 
-        public static TheoryData<string> NullTheoryData { get; }
+        public static TheoryData<string> NullTheoryData => null;
 
         [AutoData]
         [Theory(DisplayName = "GIVEN uninitialized fixture WHEN constructor is invoked THEN exception is thrown")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/MemberData/MemberAutoDataItemExtenderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/MemberData/MemberAutoDataItemExtenderTests.cs
@@ -21,8 +21,7 @@
     [Trait("Category", "MemberData")]
     public class MemberAutoDataItemExtenderTests
     {
-        private static readonly Type MemberType = typeof(MemberAutoDataItemExtenderTests);
-        private static readonly MethodInfo TestMethod = MemberType.GetMethod(nameof(MethodUnderTest), BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly MethodInfo TestMethod = typeof(MemberAutoDataItemExtenderTests).GetMethod(nameof(MethodUnderTest), BindingFlags.Instance | BindingFlags.NonPublic);
         private readonly Fixture fixture = new();
         private readonly Mock<IAutoFixtureInlineAttributeProvider> dataAttributeProvider = new();
         private readonly Mock<DataAttribute> dataAttribute = new();
@@ -51,7 +50,7 @@
             var item = this.fixture.Create<object[]>();
 
             // Act
-            var data = noDataConverter.Extend(TestMethod, item, this.memberName, MemberType);
+            var data = noDataConverter.Extend(TestMethod, item, this.memberName);
 
             // Assert
             data.Should().BeNull();
@@ -66,7 +65,7 @@
             var item = this.fixture.Create<object[]>();
 
             // Act
-            var data = this.converter.Extend(TestMethod, item, this.memberName, MemberType);
+            var data = this.converter.Extend(TestMethod, item, this.memberName);
 
             // Assert
             data.Should().NotBeNull();
@@ -81,7 +80,7 @@
             const object[] item = null;
 
             // Act
-            var data = this.converter.Extend(TestMethod, item, this.memberName, MemberType);
+            var data = this.converter.Extend(TestMethod, item, this.memberName);
 
             // Assert
             data.Should().BeNull();
@@ -95,7 +94,7 @@
             var item = this.fixture.Create<object[]>();
 
             // Act
-            Func<object> act = () => this.converter.Extend(method, item, this.memberName, MemberType);
+            Func<object> act = () => this.converter.Extend(method, item, this.memberName);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/MemberAutoDataBaseAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/MemberAutoDataBaseAttribute.cs
@@ -82,7 +82,7 @@
 
             var converter = new MemberAutoDataItemExtender(fixture, this.CreateProvider());
 
-            return converter.Extend(testMethod, values, this.MemberName, this.RetrieveMemberType(testMethod));
+            return converter.Extend(testMethod, values, this.MemberName);
         }
 
         private Type RetrieveMemberType(MethodInfo testMethod)

--- a/src/Objectivity.AutoFixture.XUnit2.Core/MemberData/IDataItemExtender.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/MemberData/IDataItemExtender.cs
@@ -1,10 +1,9 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.MemberData
 {
-    using System;
     using System.Reflection;
 
     public interface IDataItemExtender
     {
-        object[] Extend(MethodInfo testMethod, object[] values, string memberName, Type memberType);
+        object[] Extend(MethodInfo testMethod, object[] values, string memberName);
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core/MemberData/MemberAutoDataItemExtender.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/MemberData/MemberAutoDataItemExtender.cs
@@ -1,6 +1,5 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.MemberData
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
@@ -24,7 +23,7 @@
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Testable design.")]
         public IAutoFixtureInlineAttributeProvider DataAttributeProvider { get; }
 
-        public object[] Extend(MethodInfo testMethod, object[] values, string memberName, Type memberType)
+        public object[] Extend(MethodInfo testMethod, object[] values, string memberName)
         {
             if (values is null)
             {


### PR DESCRIPTION
* No need for memberType in the IDataItemExtender.Extend method
* Ensure NullTheoryData always returns null