### PR TITLE
Initial commit with first changes

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -5,8 +5,6 @@
 
     using FakeItEasy;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoFakeItEasy;
     using global::AutoFixture.Xunit2;
@@ -29,9 +27,9 @@
             var attribute = new AutoMockDataAttribute();
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.Provider.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.NotNull(attribute.Fixture);
+            Assert.NotNull(attribute.Provider);
+            Assert.False(attribute.IgnoreVirtualMembers);
         }
 
         [InlineAutoData(true)]
@@ -65,17 +63,14 @@
             var result = attribute.GetData(methodInfo);
 
             // Assert
-            result.Should().BeSameAs(data);
+            Assert.Same(data, result);
             A.CallTo(() => provider.GetAttribute(A<IFixture>._)).MustHaveHappenedOnceExactly();
             A.CallTo(() => dataAttribute.GetData(A<MethodInfo>._)).MustHaveHappenedOnceExactly();
 
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoFakeItEasyCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoFakeItEasyCustomization>(customizations[1]);
         }
 
         [AutoMockData]
@@ -85,7 +80,7 @@
             // Arrange
             // Act
             // Assert
-            value.Should().NotBe(0);
+            Assert.NotEqual(0, value);
         }
 
         [AutoMockData]
@@ -95,8 +90,9 @@
             // Arrange
             // Act
             // Assert
-            value.Should().NotBeNull();
-            value.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(value);
+            Assert.NotNull(value.StringProperty);
+            Assert.NotEmpty(value.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -46,7 +46,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            Assert.Equivalent(initialValues, attribute.Values);
+            Assert.Equal(initialValues, attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized values WHEN constructor is invoked THEN has no values and fixture and attribute provider are created")]
@@ -121,6 +121,7 @@
 
             Assert.NotNull(objectInstance);
             Assert.NotNull(objectInstance.StringProperty);
+            Assert.NotEmpty(objectInstance.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -5,8 +5,6 @@
 
     using FakeItEasy;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoFakeItEasy;
     using global::AutoFixture.Xunit2;
@@ -29,10 +27,10 @@
             var attribute = new InlineAutoMockDataAttribute();
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
-            attribute.Values.Should().HaveCount(0);
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
+            Assert.Empty(attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN existing inline values WHEN constructor is invoked THEN has specified values and fixture and attribute provider are created")]
@@ -45,10 +43,10 @@
             var attribute = new InlineAutoMockDataAttribute(initialValues[0], initialValues[1], initialValues[2]);
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
-            attribute.Values.Should().BeEquivalentTo(initialValues);
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
+            Assert.Equivalent(initialValues, attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized values WHEN constructor is invoked THEN has no values and fixture and attribute provider are created")]
@@ -61,10 +59,10 @@
             var attribute = new InlineAutoMockDataAttribute(initialValues);
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
-            attribute.Values.Should().HaveCount(0);
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
+            Assert.Empty(attribute.Values);
         }
 
         [InlineAutoData(true)]
@@ -98,17 +96,14 @@
             var result = attribute.GetData(methodInfo);
 
             // Assert
-            result.Should().BeSameAs(data);
+            Assert.Same(data, result);
             A.CallTo(() => provider.GetAttribute(A<IFixture>._)).MustHaveHappenedOnceExactly();
             A.CallTo(() => dataAttribute.GetData(A<MethodInfo>._)).MustHaveHappenedOnceExactly();
 
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoFakeItEasyCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoFakeItEasyCustomization>(customizations[1]);
         }
 
         [InlineAutoMockData(100)]
@@ -121,11 +116,11 @@
             // Arrange
             // Act
             // Assert
-            firstValueInstance.Should().Be(100);
-            secondValueInstance.Should().NotBe(0);
+            Assert.Equal(100, firstValueInstance);
+            Assert.NotEqual(0, secondValueInstance);
 
-            objectInstance.Should().NotBeNull();
-            objectInstance.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(objectInstance);
+            Assert.NotNull(objectInstance.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -51,8 +51,8 @@
             var attribute = new MemberAutoMockDataAttribute(fixture.Create<string>());
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
             attribute.ShareFixture.Should().BeTrue();
         }
 
@@ -187,8 +187,9 @@
             third.Should().BeOneOf((int)testData[0][2], (int)testData[1][2], (int)testData[2][2]);
             fourth.Should().NotBe(0);
 
-            objectInstance.Should().NotBeNull();
-            objectInstance.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(objectInstance);
+            Assert.NotNull(objectInstance.StringProperty);
+            Assert.NotEmpty(objectInstance.StringProperty);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
@@ -60,7 +60,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -29,9 +29,9 @@
             var attribute = new AutoMockDataAttribute();
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.Provider.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.NotNull(attribute.Fixture);
+            Assert.NotNull(attribute.Provider);
+            Assert.False(attribute.IgnoreVirtualMembers);
         }
 
         [InlineAutoData(true)]
@@ -95,8 +95,9 @@
             // Arrange
             // Act
             // Assert
-            value.Should().NotBeNull();
-            value.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(value);
+            Assert.NotNull(value.StringProperty);
+            Assert.NotEmpty(value.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -3,8 +3,6 @@
     using System.Collections.Generic;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoMoq;
     using global::AutoFixture.Xunit2;
@@ -65,17 +63,14 @@
             var result = attribute.GetData(methodInfo);
 
             // Assert
-            result.Should().BeSameAs(data);
+            Assert.Same(data, result);
             provider.VerifyAll();
             dataAttribute.VerifyAll();
 
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoMoqCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoMoqCustomization>(customizations[1]);
         }
 
         [AutoMockData]
@@ -85,7 +80,7 @@
             // Arrange
             // Act
             // Assert
-            value.Should().NotBe(0);
+            Assert.NotEqual(0, value);
         }
 
         [AutoMockData]

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -3,8 +3,6 @@
     using System.Collections.Generic;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoMoq;
     using global::AutoFixture.Xunit2;
@@ -32,7 +30,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            attribute.Values.Should().HaveCount(0);
+            Assert.Empty(attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN existing inline values WHEN constructor is invoked THEN has specified values and fixture and attribute provider are created")]
@@ -48,7 +46,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            attribute.Values.Should().BeEquivalentTo(initialValues);
+            Assert.Equal(initialValues, attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized values WHEN constructor is invoked THEN has no values and fixture and attribute provider are created")]
@@ -64,7 +62,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            attribute.Values.Should().HaveCount(0);
+            Assert.Empty(attribute.Values);
         }
 
         [InlineAutoData(true)]
@@ -98,17 +96,14 @@
             var result = attribute.GetData(methodInfo);
 
             // Assert
-            result.Should().BeSameAs(data);
+            Assert.Same(data, result);
             provider.VerifyAll();
             dataAttribute.VerifyAll();
 
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoMoqCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoMoqCustomization>(customizations[1]);
         }
 
         [InlineAutoMockData(100)]
@@ -121,8 +116,8 @@
             // Arrange
             // Act
             // Assert
-            firstValueInstance.Should().Be(100);
-            secondValueInstance.Should().NotBe(0);
+            Assert.Equal(100, firstValueInstance);
+            Assert.NotEqual(0, secondValueInstance);
 
             Assert.NotNull(objectInstance);
             Assert.NotNull(objectInstance.StringProperty);

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -29,9 +29,9 @@
             var attribute = new InlineAutoMockDataAttribute();
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
             attribute.Values.Should().HaveCount(0);
         }
 
@@ -45,9 +45,9 @@
             var attribute = new InlineAutoMockDataAttribute(initialValues[0], initialValues[1], initialValues[2]);
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
             attribute.Values.Should().BeEquivalentTo(initialValues);
         }
 
@@ -61,9 +61,9 @@
             var attribute = new InlineAutoMockDataAttribute(initialValues);
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
             attribute.Values.Should().HaveCount(0);
         }
 
@@ -124,8 +124,9 @@
             firstValueInstance.Should().Be(100);
             secondValueInstance.Should().NotBe(0);
 
-            objectInstance.Should().NotBeNull();
-            objectInstance.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(objectInstance);
+            Assert.NotNull(objectInstance.StringProperty);
+            Assert.NotEmpty(objectInstance.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -51,8 +51,8 @@
             var attribute = new MemberAutoMockDataAttribute(fixture.Create<string>());
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
             attribute.ShareFixture.Should().BeTrue();
         }
 
@@ -187,8 +187,9 @@
             third.Should().BeOneOf((int)testData[0][2], (int)testData[1][2], (int)testData[2][2]);
             fourth.Should().NotBe(0);
 
-            objectInstance.Should().NotBeNull();
-            objectInstance.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(objectInstance);
+            Assert.NotNull(objectInstance.StringProperty);
+            Assert.NotEmpty(objectInstance.StringProperty);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -4,8 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoMoq;
     using global::AutoFixture.Xunit2;
@@ -53,7 +51,7 @@
             // Assert
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
-            attribute.ShareFixture.Should().BeTrue();
+            Assert.True(attribute.ShareFixture);
         }
 
         [Fact(DisplayName = "GIVEN existing member name WHEN GetData is invoked THEN appropriate data is returned")]
@@ -68,15 +66,16 @@
             var data = attribute.GetData(methodInfo).ToList();
 
             // Assert
-            data.Should().HaveSameCount(TestData);
+            Assert.Equal(TestData.Count(), data.Count);
             for (var i = data.Count - 1; i >= 0; i--)
             {
                 var source = TestData.ElementAt(i);
                 var result = data.ElementAt(i);
+                var typeName = result[numberOfParameters - 1].GetType().Name;
 
-                result.Should().HaveCount(numberOfParameters);
-                result.Should().ContainInOrder(source);
-                result[numberOfParameters - 1].GetType().Name.Should().StartWith("IDisposableProxy", "that way we know it was mocked.");
+                Assert.Equal(numberOfParameters, result.Length);
+                Assert.Equal(source, result.Take(source.Length));
+                Assert.StartsWith("IDisposableProxy", typeName);
             }
         }
 
@@ -102,13 +101,10 @@
             attribute.GetData(methodInfo);
 
             // Assert
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoMoqCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoMoqCustomization>(customizations[1]);
         }
 
         [MemberAutoMockData(nameof(TestDataShareFixture), ShareFixture = true)]
@@ -122,7 +118,7 @@
             fixture.Customize(customization);
 
             // Assert
-            fixture.Customizations.Should().HaveCount(expectedCustomizationsCount + index);
+            Assert.Equal(expectedCustomizationsCount + index, fixture.Customizations.Count);
         }
 
         [MemberAutoMockData(nameof(TestDataDoNotShareFixture), ShareFixture = false)]
@@ -136,7 +132,7 @@
             fixture.Customize(customization);
 
             // Assert
-            fixture.Customizations.Should().HaveCount(expectedCustomizationsCount);
+            Assert.Equal(expectedCustomizationsCount, fixture.Customizations.Count);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized fixture WHEN constructor is invoked THEN exception is thrown")]
@@ -147,11 +143,11 @@
             const Fixture uninitializedFixture = null;
 
             // Act
-            Func<object> act = () => new MemberAutoMockDataAttribute(uninitializedFixture, fixture.Create<string>());
+            object Act() => new MemberAutoMockDataAttribute(uninitializedFixture, fixture.Create<string>());
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("fixture");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("fixture", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized member name WHEN constructor is invoked THEN exception is thrown")]
@@ -161,11 +157,11 @@
             const string memberName = null;
 
             // Act
-            Func<object> act = () => new MemberAutoMockDataAttribute(memberName);
+            static object Act() => new MemberAutoMockDataAttribute(memberName);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("memberName");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("memberName", exception.ParamName);
         }
 
         [MemberAutoMockData(nameof(TestData))]
@@ -182,10 +178,10 @@
 
             // Act
             // Assert
-            first.Should().BeOneOf((int)testData[0][0], (int)testData[1][0], (int)testData[2][0]);
-            second.Should().BeOneOf((int)testData[0][1], (int)testData[1][1], (int)testData[2][1]);
-            third.Should().BeOneOf((int)testData[0][2], (int)testData[1][2], (int)testData[2][2]);
-            fourth.Should().NotBe(0);
+            Assert.Contains(first, new[] { (int)testData[0][0], (int)testData[1][0], (int)testData[2][0] });
+            Assert.Contains(second, new[] { (int)testData[0][1], (int)testData[1][1], (int)testData[2][1] });
+            Assert.Contains(third, new[] { (int)testData[0][2], (int)testData[1][2], (int)testData[2][2] });
+            Assert.NotEqual(0, fourth);
 
             Assert.NotNull(objectInstance);
             Assert.NotNull(objectInstance.StringProperty);

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
@@ -61,7 +61,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -29,9 +29,9 @@
             var attribute = new AutoMockDataAttribute();
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.Provider.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.NotNull(attribute.Fixture);
+            Assert.NotNull(attribute.Provider);
+            Assert.False(attribute.IgnoreVirtualMembers);
         }
 
         [InlineAutoData(true)]
@@ -94,8 +94,9 @@
             // Arrange
             // Act
             // Assert
-            value.Should().NotBeNull();
-            value.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(value);
+            Assert.NotNull(value.StringProperty);
+            Assert.NotEmpty(value.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -3,8 +3,6 @@
     using System.Collections.Generic;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoNSubstitute;
     using global::AutoFixture.Xunit2;
@@ -64,17 +62,14 @@
             var result = attribute.GetData(methodInfo);
 
             // Assert
-            result.Should().BeSameAs(data);
+            Assert.Same(data, result);
             provider.Received(1).GetAttribute(Arg.Any<IFixture>());
             dataAttribute.Received(1).GetData(Arg.Any<MethodInfo>());
 
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoNSubstituteCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoNSubstituteCustomization>(customizations[1]);
         }
 
         [AutoMockData]
@@ -84,7 +79,7 @@
             // Arrange
             // Act
             // Assert
-            value.Should().NotBe(0);
+            Assert.NotEqual(0, value);
         }
 
         [AutoMockData]

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -29,9 +29,9 @@
             var attribute = new InlineAutoMockDataAttribute();
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
             attribute.Values.Should().HaveCount(0);
         }
 
@@ -45,9 +45,9 @@
             var attribute = new InlineAutoMockDataAttribute(initialValues[0], initialValues[1], initialValues[2]);
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
             attribute.Values.Should().BeEquivalentTo(initialValues);
         }
 
@@ -61,9 +61,9 @@
             var attribute = new InlineAutoMockDataAttribute(initialValues);
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
-            attribute.Provider.Should().NotBeNull();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
+            Assert.NotNull(attribute.Provider);
             attribute.Values.Should().HaveCount(0);
         }
 
@@ -123,7 +123,7 @@
             firstValueInstance.Should().Be(100);
             secondValueInstance.Should().NotBe(0);
 
-            objectInstance.Should().NotBeNull();
+            Assert.NotNull(objectInstance);
             objectInstance.StringProperty.Should().NotBeNullOrEmpty();
         }
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -3,8 +3,6 @@
     using System.Collections.Generic;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoNSubstitute;
     using global::AutoFixture.Xunit2;
@@ -32,7 +30,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            attribute.Values.Should().HaveCount(0);
+            Assert.Empty(attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN existing inline values WHEN constructor is invoked THEN has specified values and fixture and attribute provider are created")]
@@ -48,7 +46,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            attribute.Values.Should().BeEquivalentTo(initialValues);
+            Assert.Equal(initialValues, attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized values WHEN constructor is invoked THEN has no values and fixture and attribute provider are created")]
@@ -64,7 +62,7 @@
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
             Assert.NotNull(attribute.Provider);
-            attribute.Values.Should().HaveCount(0);
+            Assert.Empty(attribute.Values);
         }
 
         [InlineAutoData(true)]
@@ -97,17 +95,14 @@
             var result = attribute.GetData(methodInfo);
 
             // Assert
-            result.Should().BeSameAs(data);
+            Assert.Same(data, result);
             provider.Received(1).GetAttribute(Arg.Any<IFixture>());
             dataAttribute.Received(1).GetData(Arg.Any<MethodInfo>());
 
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoNSubstituteCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoNSubstituteCustomization>(customizations[1]);
         }
 
         [InlineAutoMockData(100)]
@@ -120,11 +115,12 @@
             // Arrange
             // Act
             // Assert
-            firstValueInstance.Should().Be(100);
-            secondValueInstance.Should().NotBe(0);
+            Assert.Equal(100, firstValueInstance);
+            Assert.NotEqual(0, secondValueInstance);
 
             Assert.NotNull(objectInstance);
-            objectInstance.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(objectInstance.StringProperty);
+            Assert.NotEmpty(objectInstance.StringProperty);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -51,8 +51,8 @@
             var attribute = new MemberAutoMockDataAttribute(fixture.Create<string>());
 
             // Assert
-            attribute.Fixture.Should().NotBeNull();
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.NotNull(attribute.Fixture);
+            Assert.False(attribute.IgnoreVirtualMembers);
             attribute.ShareFixture.Should().BeTrue();
         }
 
@@ -186,7 +186,7 @@
             third.Should().BeOneOf((int)testData[0][2], (int)testData[1][2], (int)testData[2][2]);
             fourth.Should().NotBe(0);
 
-            objectInstance.Should().NotBeNull();
+            Assert.NotNull(objectInstance);
             objectInstance.StringProperty.Should().NotBeNullOrEmpty();
         }
     }

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -4,8 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.AutoNSubstitute;
     using global::AutoFixture.Xunit2;
@@ -53,7 +51,7 @@
             // Assert
             Assert.NotNull(attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
-            attribute.ShareFixture.Should().BeTrue();
+            Assert.True(attribute.ShareFixture);
         }
 
         [Fact(DisplayName = "GIVEN existing member name WHEN GetData is invoked THEN appropriate data is returned")]
@@ -68,15 +66,16 @@
             var data = attribute.GetData(methodInfo).ToList();
 
             // Assert
-            data.Should().HaveSameCount(TestData);
+            Assert.Equal(TestData.Count(), data.Count);
             for (var i = data.Count - 1; i >= 0; i--)
             {
                 var source = TestData.ElementAt(i);
                 var result = data.ElementAt(i);
+                var typeName = result[numberOfParameters - 1].GetType().Name;
 
-                result.Should().HaveCount(numberOfParameters);
-                result.Should().ContainInOrder(source);
-                result[numberOfParameters - 1].GetType().Name.Should().StartWith("ObjectProxy", "that way we know it was mocked.");
+                Assert.Equal(numberOfParameters, result.Length);
+                Assert.Equal(source, result.Take(source.Length));
+                Assert.StartsWith("ObjectProxy", typeName);
             }
         }
 
@@ -101,13 +100,10 @@
             attribute.GetData(methodInfo);
 
             // Assert
-            customizations.Count.Should().Be(2);
-            customizations[0]
-                .Should()
-                .BeOfType<AutoDataCommonCustomization>()
-                .Which.IgnoreVirtualMembers.Should()
-                .Be(ignoreVirtualMembers);
-            customizations[1].Should().BeOfType<AutoNSubstituteCustomization>();
+            Assert.Equal(2, customizations.Count);
+            var customization = Assert.IsType<AutoDataCommonCustomization>(customizations[0]);
+            Assert.Equal(ignoreVirtualMembers, customization.IgnoreVirtualMembers);
+            Assert.IsType<AutoNSubstituteCustomization>(customizations[1]);
         }
 
         [MemberAutoMockData(nameof(TestDataShareFixture), ShareFixture = true)]
@@ -121,7 +117,7 @@
             fixture.Customize(customization);
 
             // Assert
-            fixture.Customizations.Should().HaveCount(expectedCustomizationsCount + index);
+            Assert.Equal(expectedCustomizationsCount + index, fixture.Customizations.Count);
         }
 
         [MemberAutoMockData(nameof(TestDataDoNotShareFixture), ShareFixture = false)]
@@ -135,7 +131,7 @@
             fixture.Customize(customization);
 
             // Assert
-            fixture.Customizations.Should().HaveCount(expectedCustomizationsCount);
+            Assert.Equal(expectedCustomizationsCount, fixture.Customizations.Count);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized fixture WHEN constructor is invoked THEN exception is thrown")]
@@ -146,11 +142,11 @@
             const Fixture uninitializedFixture = null;
 
             // Act
-            Func<object> act = () => new MemberAutoMockDataAttribute(uninitializedFixture, fixture.Create<string>());
+            object Act() => new MemberAutoMockDataAttribute(uninitializedFixture, fixture.Create<string>());
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("fixture");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("fixture", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized member name WHEN constructor is invoked THEN exception is thrown")]
@@ -160,11 +156,11 @@
             const string memberName = null;
 
             // Act
-            Func<object> act = () => new MemberAutoMockDataAttribute(memberName);
+            static object Act() => new MemberAutoMockDataAttribute(memberName);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("memberName");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("memberName", exception.ParamName);
         }
 
         [MemberAutoMockData(nameof(TestData))]
@@ -181,13 +177,14 @@
 
             // Act
             // Assert
-            first.Should().BeOneOf((int)testData[0][0], (int)testData[1][0], (int)testData[2][0]);
-            second.Should().BeOneOf((int)testData[0][1], (int)testData[1][1], (int)testData[2][1]);
-            third.Should().BeOneOf((int)testData[0][2], (int)testData[1][2], (int)testData[2][2]);
-            fourth.Should().NotBe(0);
+            Assert.Contains(first, new[] { (int)testData[0][0], (int)testData[1][0], (int)testData[2][0] });
+            Assert.Contains(second, new[] { (int)testData[0][1], (int)testData[1][1], (int)testData[2][1] });
+            Assert.Contains(third, new[] { (int)testData[0][2], (int)testData[1][2], (int)testData[2][2] });
+            Assert.NotEqual(0, fourth);
 
             Assert.NotNull(objectInstance);
-            objectInstance.StringProperty.Should().NotBeNullOrEmpty();
+            Assert.NotNull(objectInstance.StringProperty);
+            Assert.NotEmpty(objectInstance.StringProperty);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
@@ -60,7 +60,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataBaseAttributeTests.cs
@@ -2,8 +2,6 @@
 {
     using System;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Moq;
@@ -28,8 +26,8 @@
             var attribute = new AutoDataBaseAttributeUnderTest(fixture, provider.Object);
 
             // Assert
-            attribute.Fixture.Should().Be(fixture);
-            attribute.Provider.Should().Be(provider.Object);
+            Assert.Equal(fixture, attribute.Fixture);
+            Assert.Equal(provider.Object, attribute.Provider);
             Assert.False(attribute.IgnoreVirtualMembers);
         }
 
@@ -41,11 +39,11 @@
             var provider = new Mock<IAutoFixtureAttributeProvider>();
 
             // Act
-            Func<object> act = () => new AutoDataBaseAttributeUnderTest(fixture, provider.Object);
+            object Act() => new AutoDataBaseAttributeUnderTest(fixture, provider.Object);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("fixture");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("fixture", exception.ParamName);
         }
 
         [AutoData]
@@ -56,11 +54,11 @@
             const IAutoFixtureAttributeProvider provider = null;
 
             // Act
-            Func<object> act = () => new AutoDataBaseAttributeUnderTest(fixture, provider);
+            object Act() => new AutoDataBaseAttributeUnderTest(fixture, provider);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("provider");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("provider", exception.ParamName);
         }
 
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataBaseAttributeTests.cs
@@ -30,7 +30,7 @@
             // Assert
             attribute.Fixture.Should().Be(fixture);
             attribute.Provider.Should().Be(provider.Object);
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.False(attribute.IgnoreVirtualMembers);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized fixture WHEN constructor is invoked THEN exception is thrown")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/CustomizeWithAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/CustomizeWithAttributeTests.cs
@@ -6,8 +6,6 @@
     using System.Linq;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
     using global::AutoFixture.Xunit2;
@@ -42,7 +40,8 @@
             var customization = customizeAttribute.GetCustomization(null);
 
             // Assert
-            customization.Should().NotBeNull().And.BeAssignableTo(customizationType);
+            Assert.NotNull(customization);
+            Assert.IsType(customizationType, customization);
         }
 
         [Fact(DisplayName = "GIVEN customization type with arguments WHEN GetCustomization is invoked THEN customization instance is returned")]
@@ -56,7 +55,8 @@
             var customization = customizeAttribute.GetCustomization(null);
 
             // Assert
-            customization.Should().NotBeNull().And.BeAssignableTo(customizationType);
+            Assert.NotNull(customization);
+            Assert.IsType(customizationType, customization);
         }
 
         [Fact(DisplayName = "GIVEN customization type requiring arguments without any WHEN GetCustomization is invoked THEN exception is thrown")]
@@ -67,10 +67,10 @@
             var customizeAttribute = new CustomizeWithAttribute(customizationType);
 
             // Act
-            Func<object> act = () => customizeAttribute.GetCustomization(null);
+            object Act() => customizeAttribute.GetCustomization(null);
 
             // Assert
-            act.Should().Throw<MissingMethodException>();
+            Assert.Throws<MissingMethodException>(Act);
         }
 
         [Fact(DisplayName = "GIVEN CustomizeWithAttribute with IncludeParameterType set WHEN GetCustomization without ParameterInfo is invoked THEN exception is thrown")]
@@ -81,11 +81,11 @@
             var customizeAttribute = new CustomizeWithAttribute(customizationType) { IncludeParameterType = true };
 
             // Act
-            Func<object> act = () => customizeAttribute.GetCustomization(null);
+            object Act() => customizeAttribute.GetCustomization(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("parameter");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("parameter", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized type WHEN constructor is invoked THEN exception is thrown")]
@@ -95,11 +95,11 @@
             const Type customizationType = null;
 
             // Act
-            Func<object> act = () => new CustomizeWithAttribute(customizationType);
+            static object Act() => new CustomizeWithAttribute(customizationType);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("type");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("type", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN unsupported type WHEN constructor is invoked THEN exception is thrown")]
@@ -109,12 +109,13 @@
             var customizationType = typeof(string);
 
             // Act
-            Func<object> act = () => new CustomizeWithAttribute(customizationType);
+            object Act() => new CustomizeWithAttribute(customizationType);
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain(nameof(ICustomization));
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains(nameof(ICustomization), exception.Message);
         }
 
         [Fact(DisplayName = "GIVEN CustomizeWith attribute with IncludeParameterType set WHEN GetCustomization is invoked THEN customization with expected type is returned")]
@@ -132,8 +133,10 @@
             var customization = customizeAttribute.GetCustomization(parameter) as ArgumentsDiscoveryCustomization;
 
             // Assert
-            customization.Should().NotBeNull().And.BeAssignableTo(customizationType);
-            customization.Args.Should().HaveCount(1).And.Subject.First().Should().Be(parameter.ParameterType);
+            Assert.NotNull(customization);
+            Assert.IsType(customizationType, customization);
+            Assert.Single(customization.Args);
+            Assert.Equal(parameter.ParameterType, customization.Args.First());
         }
 
         [MemberData(nameof(ArgumentsDiscoveryCustomizationTestData))]
@@ -152,8 +155,9 @@
             var customization = customizeAttribute.GetCustomization(parameter) as ArgumentsDiscoveryCustomization;
 
             // Assert
-            customization.Should().NotBeNull().And.BeAssignableTo(customizationType);
-            customization.Args.Should().HaveCount(expectedNumberOfArguments);
+            Assert.NotNull(customization);
+            Assert.IsType(customizationType, customization);
+            Assert.Equal(expectedNumberOfArguments, customization.Args.Count);
         }
 
         [AutoData]
@@ -165,8 +169,8 @@
             // Arrange
             // Act
             // Assert
-            instanceWithoutCustomization.Should().NotBeEmpty();
-            instanceWithCustomization.Should().BeEmpty();
+            Assert.NotEmpty(instanceWithoutCustomization);
+            Assert.Empty(instanceWithCustomization);
         }
 
         [AutoData]
@@ -178,8 +182,8 @@
             // Arrange
             // Act
             // Assert
-            instanceWithoutCustomization.Should().BeEmpty();
-            instanceWithCustomization.Should().BeEmpty();
+            Assert.Empty(instanceWithoutCustomization);
+            Assert.Empty(instanceWithCustomization);
         }
 
         [AutoData]
@@ -191,8 +195,8 @@
             // Arrange
             // Act
             // Assert
-            instanceWithCustomization.Should().BeEmpty();
-            instanceOfDifferentTypeWithoutCustomization.Should().NotBeEmpty();
+            Assert.Empty(instanceWithCustomization);
+            Assert.NotEmpty(instanceOfDifferentTypeWithoutCustomization);
         }
 
         [SuppressMessage("Roslynator", "RCS1163:Unused parameter.", Justification = "Required for test.")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/ExceptAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/ExceptAttributeTests.cs
@@ -4,8 +4,6 @@
     using System.Linq;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
     using global::AutoFixture.Xunit2;
@@ -47,11 +45,11 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new ExceptAttribute(null);
+            static object Act() => new ExceptAttribute(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("values");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("values", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN no arguments WHEN constructor is invoked THEN exception is thrown")]
@@ -59,12 +57,13 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new ExceptAttribute();
+            static object Act() => new ExceptAttribute();
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("At least one value");
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("At least one value", exception.Message);
         }
 
         [AutoData]
@@ -76,11 +75,11 @@
             var attribute = new ExceptAttribute(values);
 
             // Act
-            Action act = () => attribute.GetCustomization(null);
+            void Act() => attribute.GetCustomization(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("parameter");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("parameter", exception.ParamName);
         }
 
         [InlineData(1, 1)]
@@ -94,7 +93,8 @@
             var attribute = new ExceptAttribute(first, second);
 
             // Assert
-            attribute.Values.Should().HaveCount(1).And.BeEquivalentTo(new[] { first });
+            Assert.Single(attribute.Values);
+            Assert.Equivalent(new[] { first }, attribute.Values);
         }
 
         [InlineData(typeof(int), 2)]
@@ -109,7 +109,8 @@
             var attribute = new ExceptAttribute(first, second);
 
             // Assert
-            attribute.Values.Should().HaveCount(2).And.BeEquivalentTo(new[] { first, second });
+            Assert.Equal(2, attribute.Values.Count);
+            Assert.Equivalent(new[] { first, second }, attribute.Values);
         }
 
         [MemberData(nameof(CustomizationUsageTestData))]
@@ -130,9 +131,9 @@
             var result = fixture.Create(request.Object, new SpecimenContext(fixture));
 
             // Assert
-            result.Should().NotBeNull()
-                .And.BeOfType(expectedType)
-                .And.NotBe(item);
+            Assert.NotNull(result);
+            Assert.IsType(expectedType, result);
+            Assert.NotEqual(item, result);
         }
 
         [AutoData]
@@ -148,7 +149,7 @@
             // Arrange
             // Act
             // Assert
-            targetValues.Should().AllSatisfy(x => x.Should().Be(Numbers.Five));
+            Assert.All(targetValues, x => Assert.Equal(Numbers.Five, x));
         }
 
         [AutoData]
@@ -165,8 +166,8 @@
             // Arrange
             // Act
             // Assert
-            firstSet.Should().AllSatisfy(x => x.Should().Be(Numbers.Five));
-            secondSet.Where(x => x != Numbers.Five).Should().HaveCountGreaterThan(1);
+            Assert.All(firstSet, x => Assert.Equal(Numbers.Five, x));
+            Assert.True(secondSet.Count(x => x != Numbers.Five) > 1);
         }
 
         [AutoData]
@@ -182,10 +183,13 @@
                 Numbers.Five)] Numbers[] secondSet)
         {
             // Arrange
+            var expectedFirstSet = new[] { Numbers.Three, Numbers.Four, Numbers.Five };
+            var expectedSecondSet = new[] { Numbers.None, Numbers.One, Numbers.Two };
+
             // Act
             // Assert
-            firstSet.Should().AllSatisfy(x => x.Should().BeOneOf(Numbers.Three, Numbers.Four, Numbers.Five));
-            secondSet.Should().AllSatisfy(x => x.Should().BeOneOf(Numbers.None, Numbers.One, Numbers.Two));
+            Assert.All(firstSet, x => Assert.Contains(x, expectedFirstSet));
+            Assert.All(secondSet, x => Assert.Contains(x, expectedSecondSet));
         }
 
         [AutoData]
@@ -202,8 +206,8 @@
             // Arrange
             // Act
             // Assert
-            firstValue.Should().Be(Numbers.Five);
-            secondValue.Should().Be(firstValue);
+            Assert.Equal(Numbers.Five, firstValue);
+            Assert.Equal(firstValue, secondValue);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/IgnoreVirtualMembersAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/IgnoreVirtualMembersAttributeTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
-
-    using FluentAssertions;
     using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
 
@@ -32,11 +30,11 @@
             [IgnoreVirtualMembers] UserWithSubstitute userWithSubstitute,
             User user)
         {
-            userWithSubstitute.Name.Should().BeNull();
-            userWithSubstitute.Substitute.Should().BeNull();
+            Assert.Null(userWithSubstitute.Name);
+            Assert.Null(userWithSubstitute.Substitute);
 
-            user.Name.Should().NotBeNull();
-            user.Address.Should().NotBeNull();
+            Assert.NotNull(user.Name);
+            Assert.NotNull(user.Address);
         }
 
         [AutoData]
@@ -45,11 +43,11 @@
             UserWithSubstitute userWithSubstitute,
             [IgnoreVirtualMembers] User user)
         {
-            userWithSubstitute.Name.Should().NotBeNull();
-            userWithSubstitute.Substitute.Should().NotBeNull();
+            Assert.NotNull(userWithSubstitute.Name);
+            Assert.NotNull(userWithSubstitute.Substitute);
 
-            user.Name.Should().NotBeNull();
-            user.Address.Should().BeNull();
+            Assert.NotNull(user.Name);
+            Assert.Null(user.Address);
         }
 
         [AutoData]
@@ -59,14 +57,14 @@
             [IgnoreVirtualMembers] UserWithSubstitute user2,
             UserWithSubstitute user3)
         {
-            user1.Name.Should().NotBeNull();
-            user1.Substitute.Should().NotBeNull();
+            Assert.NotNull(user1.Name);
+            Assert.NotNull(user1.Substitute);
 
-            user2.Name.Should().BeNull();
-            user2.Substitute.Should().BeNull();
+            Assert.Null(user2.Name);
+            Assert.Null(user2.Substitute);
 
-            user3.Name.Should().BeNull();
-            user3.Substitute.Should().BeNull();
+            Assert.Null(user3.Name);
+            Assert.Null(user3.Substitute);
         }
 
         [AutoData]
@@ -75,18 +73,18 @@
             [IgnoreVirtualMembers] UserWithSubstitute user1,
             UserWithSubstitute user2)
         {
-            user1.Name.Should().BeNull();
-            user1.Substitute.Should().BeNull();
+            Assert.Null(user1.Name);
+            Assert.Null(user1.Substitute);
 
-            user2.Name.Should().BeNull();
-            user2.Substitute.Should().BeNull();
+            Assert.Null(user2.Name);
+            Assert.Null(user2.Substitute);
         }
 
         [AutoData]
-        [Theory(DisplayName = "GIVEN test method has value parameter WHEN  is decorated with IgnoreVirtualMembersAttribute THEN parameter value is being populated")]
-        public void GivenTestMethodHasValueParameter_WhenIsDecoratedWithIgnoreVirtualMembersAttribute_ThenParameterValueIsBeingPopulated([IgnoreVirtualMembers] uint number)
+        [Theory(DisplayName = "GIVEN test method has value parameter WHEN is decorated with IgnoreVirtualMembersAttribute THEN parameter value is being populated")]
+        public void GivenTestMethodHasValueParameter_WhenIsDecoratedWithIgnoreVirtualMembersAttribute_ThenParameterValueIsBeingPopulated([IgnoreVirtualMembers] int number)
         {
-            number.Should().BeGreaterThanOrEqualTo(0);
+            Assert.NotEqual(default, number);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized parameter info WHEN GetCustomization is invoked THEN exception is thrown")]
@@ -97,11 +95,11 @@
             var attribute = new IgnoreVirtualMembersAttribute();
 
             // Act
-            Func<object> act = () => attribute.GetCustomization(parameterInfo);
+            object Act() => attribute.GetCustomization(parameterInfo);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("parameter");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("parameter", exception.ParamName);
         }
 
         public class Address

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/InlineAutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/InlineAutoDataBaseAttributeTests.cs
@@ -2,8 +2,6 @@
 {
     using System;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Moq;
@@ -28,10 +26,10 @@
             var attribute = new InlineAutoDataBaseAttributeUnderTest(fixture, provider.Object);
 
             // Assert
-            attribute.Fixture.Should().Be(fixture);
+            Assert.Equal(fixture, attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
-            attribute.Provider.Should().Be(provider.Object);
-            attribute.Values.Should().HaveCount(0);
+            Assert.Equal(provider.Object, attribute.Provider);
+            Assert.Empty(attribute.Values);
         }
 
         [AutoData]
@@ -46,10 +44,10 @@
             var attribute = new InlineAutoDataBaseAttributeUnderTest(fixture, provider.Object, initialValues[0], initialValues[1], initialValues[2]);
 
             // Assert
-            attribute.Fixture.Should().Be(fixture);
+            Assert.Equal(fixture, attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
-            attribute.Provider.Should().Be(provider.Object);
-            attribute.Values.Should().BeEquivalentTo(initialValues);
+            Assert.Equal(provider.Object, attribute.Provider);
+            Assert.Equal(initialValues, attribute.Values);
         }
 
         [AutoData]
@@ -64,10 +62,10 @@
             var attribute = new InlineAutoDataBaseAttributeUnderTest(fixture, provider.Object, initialValues);
 
             // Assert
-            attribute.Fixture.Should().Be(fixture);
+            Assert.Equal(fixture, attribute.Fixture);
             Assert.False(attribute.IgnoreVirtualMembers);
-            attribute.Provider.Should().Be(provider.Object);
-            attribute.Values.Should().HaveCount(0);
+            Assert.Equal(provider.Object, attribute.Provider);
+            Assert.Empty(attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized fixture WHEN constructor is invoked THEN exception is thrown")]
@@ -78,11 +76,11 @@
             var provider = new Mock<IAutoFixtureInlineAttributeProvider>();
 
             // Act
-            Func<object> act = () => new InlineAutoDataBaseAttributeUnderTest(fixture, provider.Object);
+            object Act() => new InlineAutoDataBaseAttributeUnderTest(fixture, provider.Object);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("fixture");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("fixture", exception.ParamName);
         }
 
         [AutoData]
@@ -93,11 +91,11 @@
             const IAutoFixtureInlineAttributeProvider provider = null;
 
             // Act
-            Func<object> act = () => new InlineAutoDataBaseAttributeUnderTest(fixture, provider);
+            object Act() => new InlineAutoDataBaseAttributeUnderTest(fixture, provider);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("provider");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("provider", exception.ParamName);
         }
 
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/InlineAutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/InlineAutoDataBaseAttributeTests.cs
@@ -29,7 +29,7 @@
 
             // Assert
             attribute.Fixture.Should().Be(fixture);
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.False(attribute.IgnoreVirtualMembers);
             attribute.Provider.Should().Be(provider.Object);
             attribute.Values.Should().HaveCount(0);
         }
@@ -47,7 +47,7 @@
 
             // Assert
             attribute.Fixture.Should().Be(fixture);
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.False(attribute.IgnoreVirtualMembers);
             attribute.Provider.Should().Be(provider.Object);
             attribute.Values.Should().BeEquivalentTo(initialValues);
         }
@@ -65,7 +65,7 @@
 
             // Assert
             attribute.Fixture.Should().Be(fixture);
-            attribute.IgnoreVirtualMembers.Should().BeFalse();
+            Assert.False(attribute.IgnoreVirtualMembers);
             attribute.Provider.Should().Be(provider.Object);
             attribute.Values.Should().HaveCount(0);
         }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/MemberAutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/MemberAutoDataBaseAttributeTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Moq;
@@ -39,11 +37,11 @@
             var provider = new Mock<IAutoFixtureAttributeProvider>();
 
             // Act
-            Func<object> act = () => new MemberAutoDataBaseAttributeUnderTest(fixture, memberName, provider.Object);
+            object Act() => new MemberAutoDataBaseAttributeUnderTest(fixture, memberName, provider.Object);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("fixture");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("fixture", exception.ParamName);
         }
 
         [MemberData(nameof(MemberTypeTestData))]
@@ -59,12 +57,14 @@
             var attribute = new MemberAutoDataBaseAttributeUnderTest(fixture, memberName) { MemberType = memberType };
 
             // Act
-            Func<object[]> act = () => attribute.CallConvertDataItem(TestMethod, item);
+            object[] Act() => attribute.CallConvertDataItem(TestMethod, item);
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain(memberName).And.Contain(expectedTypeName);
+            var exception = Assert.Throws<ArgumentException>((Func<object[]>)Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains(memberName, exception.Message);
+            Assert.Contains(expectedTypeName, exception.Message);
         }
 
         [Fact(DisplayName = "GIVEN array WHEN ConvertDataItem is invoked THEN the same array is returned")]
@@ -79,7 +79,7 @@
             var data = attribute.CallConvertDataItem(TestMethod, array);
 
             // Assert
-            data.Should().BeEquivalentTo(array);
+            Assert.Equal(array, data);
         }
 
         [Fact(DisplayName = "GIVEN null theory data WHEN GetData is invoked THEN null is returned")]
@@ -93,7 +93,7 @@
             var data = attribute.GetData(TestMethod);
 
             // Assert
-            data.Should().BeNull();
+            Assert.Null(data);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/PickFromRangeAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/PickFromRangeAttributeTests.cs
@@ -5,8 +5,6 @@
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
 
-    using FluentAssertions;
-
     using global::AutoFixture.Xunit2;
 
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
@@ -30,12 +28,13 @@
             const int max = 1;
 
             // Act
-            Func<object> act = () => new PickFromRangeAttribute(min, max);
+            static object Act() => new PickFromRangeAttribute(min, max);
 
             // Assert
-            act.Should().Throw<ArgumentOutOfRangeException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("must be lower or equal");
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("must be lower or equal", exception.Message);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized argument WHEN GetCustomization is invoked THEN exception is thrown")]
@@ -47,11 +46,11 @@
             var attribute = new PickFromRangeAttribute(min, max);
 
             // Act
-            Action act = () => attribute.GetCustomization(null);
+            void Act() => attribute.GetCustomization(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("parameter");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("parameter", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN valid parameters WHEN constructor is invoked THEN parameters are properly assigned")]
@@ -65,8 +64,8 @@
             var range = new PickFromRangeAttribute(min, max);
 
             // Assert
-            range.Maximum.Should().NotBeNull().And.Be(max);
-            range.Minimum.Should().NotBeNull().And.Be(min);
+            Assert.Equal(max, range.Maximum);
+            Assert.Equal(min, range.Minimum);
         }
 
         [AutoData]
@@ -77,7 +76,7 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(byte.MaxValue - 10, byte.MaxValue);
+            Assert.InRange(rangeValue, byte.MaxValue - 10, byte.MaxValue);
         }
 
         [AutoData]
@@ -88,7 +87,7 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(ushort.MaxValue - 10, ushort.MaxValue);
+            Assert.InRange(rangeValue, ushort.MaxValue - 10, ushort.MaxValue);
         }
 
         [AutoData]
@@ -99,7 +98,7 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(uint.MaxValue - 10, uint.MaxValue);
+            Assert.InRange(rangeValue, uint.MaxValue - 10, uint.MaxValue);
         }
 
         [AutoData]
@@ -110,7 +109,7 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(ulong.MaxValue - 10, ulong.MaxValue);
+            Assert.InRange(rangeValue, ulong.MaxValue - 10, ulong.MaxValue);
         }
 
         [AutoData]
@@ -121,7 +120,7 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(sbyte.MaxValue - 10, sbyte.MaxValue);
+            Assert.InRange(rangeValue, sbyte.MaxValue - 10, sbyte.MaxValue);
         }
 
         [AutoData]
@@ -133,8 +132,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(short.MinValue, short.MinValue + 10);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.InRange(rangeValue, short.MinValue, short.MinValue + 10);
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -146,8 +145,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(int.MinValue, sbyte.MinValue);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.InRange(rangeValue, int.MinValue, sbyte.MinValue);
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -159,8 +158,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(long.MinValue, long.MinValue + 10);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.InRange(rangeValue, long.MinValue, long.MinValue + 10);
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -172,8 +171,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(float.MinValue, float.MinValue + 10);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.InRange(rangeValue, float.MinValue, float.MinValue + 10);
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -185,8 +184,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(double.MinValue, double.MinValue + 10);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.InRange(rangeValue, double.MinValue, double.MinValue + 10);
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -198,8 +197,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValue.Should().BeInRange(-12.3m, -4.5m);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.InRange(rangeValue, -12.3m, -4.5m);
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [InlineAutoData(10, 10)]
@@ -213,8 +212,9 @@
             // Arrange
             // Act
             // Assert
-            value.Should().Be(expectedResult).And.NotBeInRange(int.MinValue, sbyte.MinValue);
-            unrestrictedValue.Should().BeInRange(short.MinValue, sbyte.MinValue);
+            Assert.Equal(expectedResult, value);
+            Assert.NotInRange(value, int.MinValue, sbyte.MinValue);
+            Assert.InRange(unrestrictedValue, short.MinValue, sbyte.MinValue);
         }
 
         [MemberAutoData(nameof(MemberAutoDataOverValuesTestData))]
@@ -227,8 +227,9 @@
             // Arrange
             // Act
             // Assert
-            value.Should().Be(expectedResult).And.NotBeInRange(int.MinValue, sbyte.MinValue);
-            unrestrictedValue.Should().BeInRange(int.MinValue, sbyte.MinValue);
+            Assert.Equal(expectedResult, value);
+            Assert.NotInRange(value, int.MinValue, sbyte.MinValue);
+            Assert.InRange(unrestrictedValue, int.MinValue, sbyte.MinValue);
         }
 
         [AutoData]
@@ -240,8 +241,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().AllSatisfy(x => x.Should().BeInRange(int.MinValue, sbyte.MinValue));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(rangeValues, value => Assert.InRange(value, int.MinValue, sbyte.MinValue));
+            Assert.All(unrestrictedValues, value => Assert.True(value >= 0));
         }
 
         [AutoData]
@@ -253,8 +254,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().AllSatisfy(x => x.Should().BeInRange(int.MinValue, sbyte.MinValue));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(rangeValues, value => Assert.InRange(value, int.MinValue, sbyte.MinValue));
+            Assert.All(unrestrictedValues, value => Assert.True(value >= 0));
         }
 
         [AutoData]
@@ -267,8 +268,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().AllSatisfy(x => x.Should().BeInRange(int.MinValue, sbyte.MinValue));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(rangeValues, value => Assert.InRange(value, int.MinValue, sbyte.MinValue));
+            Assert.All(unrestrictedValues, value => Assert.True(value >= 0));
         }
 
         [AutoData]
@@ -280,8 +281,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().AllSatisfy(x => x.Should().BeInRange(int.MinValue, sbyte.MinValue));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(rangeValues, value => Assert.InRange(value, int.MinValue, sbyte.MinValue));
+            Assert.All(unrestrictedValues, value => Assert.True(value >= 0));
         }
 
         [AutoData]
@@ -294,8 +295,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().AllSatisfy(x => x.Should().BeInRange(int.MinValue, sbyte.MinValue));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(rangeValues, value => Assert.InRange(value, int.MinValue, sbyte.MinValue));
+            Assert.All(unrestrictedValues, value => Assert.True(value >= 0));
         }
 
         [AutoData]
@@ -308,8 +309,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().AllSatisfy(x => x.Should().BeInRange(int.MinValue, sbyte.MinValue));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(rangeValues, value => Assert.InRange(value, int.MinValue, sbyte.MinValue));
+            Assert.All(unrestrictedValues, value => Assert.True(value >= 0));
         }
 
         [AutoData]
@@ -320,7 +321,8 @@
             // Arrange
             // Act
             // Assert
-            rangeValues.Should().HaveCountGreaterThan(1).And.AllSatisfy(x => x.Should().Be(int.MinValue));
+            Assert.True(rangeValues.Length > 1);
+            Assert.All(rangeValues, value => Assert.Equal(int.MinValue, value));
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/PickFromValuesAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/PickFromValuesAttributeTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Attributes
 {
     using System;
-    using System.Linq;
     using System.Reflection;
-
-    using FluentAssertions;
 
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
@@ -54,11 +51,11 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new PickFromValuesAttribute(null);
+            static object Act() => new PickFromValuesAttribute(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("values");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("values", exception.ParamName);
         }
 
         [AutoData]
@@ -70,11 +67,11 @@
             var attribute = new PickFromValuesAttribute(values);
 
             // Act
-            Action act = () => attribute.GetCustomization(null);
+            void Act() => attribute.GetCustomization(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("parameter");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("parameter", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN no arguments WHEN constructor is invoked THEN exception is thrown")]
@@ -82,12 +79,13 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new PickFromValuesAttribute();
+            static object Act() => new PickFromValuesAttribute();
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("At least one value");
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("At least one value", exception.Message);
         }
 
         [InlineData(1, 1)]
@@ -101,7 +99,8 @@
             var attribute = new PickFromValuesAttribute(first, second);
 
             // Assert
-            attribute.Values.Should().HaveCount(1).And.BeEquivalentTo(new[] { first });
+            Assert.Single(attribute.Values);
+            Assert.Equivalent(new[] { first }, attribute.Values);
         }
 
         [InlineData(typeof(int), 2)]
@@ -116,7 +115,8 @@
             var attribute = new PickFromValuesAttribute(first, second);
 
             // Assert
-            attribute.Values.Should().HaveCount(2).And.BeEquivalentTo(new[] { first, second });
+            Assert.Equal(2, attribute.Values.Count);
+            Assert.Equivalent(new[] { first, second }, attribute.Values);
         }
 
         [MemberData(nameof(CustomizationUsageTestData))]
@@ -137,7 +137,8 @@
             item = (T)fixture.Create(request.Object, new SpecimenContext(fixture));
 
             // Assert
-            item.Should().NotBeNull().And.Match(x => values.Contains(x));
+            Assert.NotNull(item);
+            Assert.Contains(item, values);
         }
 
         [AutoData]
@@ -148,7 +149,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(1, 5, 20);
+            Assert.Contains(targetValue, new byte[] { 1, 5, 20 });
         }
 
         [AutoData]
@@ -159,7 +160,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(1, 5, 4);
+            Assert.Contains(targetValue, new ushort[] { 1, 5, 4 });
         }
 
         [AutoData]
@@ -170,7 +171,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(1, long.MaxValue, ulong.MaxValue);
+            Assert.Contains(targetValue, new ulong[] { 1, long.MaxValue, ulong.MaxValue });
         }
 
         [AutoData]
@@ -181,7 +182,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(sbyte.MinValue, -50, -1);
+            Assert.Contains(targetValue, new sbyte[] { sbyte.MinValue, -50, -1 });
         }
 
         [AutoData]
@@ -193,8 +194,8 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(short.MinValue, sbyte.MinValue, -1);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.Contains(targetValue, new short[] { short.MinValue, sbyte.MinValue, -1 });
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -206,8 +207,8 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(int.MinValue, short.MinValue, sbyte.MinValue);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.Contains(targetValue, new int[] { int.MinValue, short.MinValue, sbyte.MinValue });
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -219,8 +220,8 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(long.MinValue, int.MinValue, short.MinValue);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.Contains(targetValue, new long[] { long.MinValue, int.MinValue, short.MinValue });
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -232,8 +233,8 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(float.MinValue, int.MinValue, short.MinValue);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.Contains(targetValue, new float[] { float.MinValue, int.MinValue, short.MinValue });
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -245,8 +246,8 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(double.MinValue, float.MinValue, int.MinValue, short.MinValue);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.Contains(targetValue, new double[] { double.MinValue, float.MinValue, int.MinValue, short.MinValue });
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -258,8 +259,8 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(long.MinValue, int.MinValue, short.MinValue);
-            unrestrictedValue.Should().BeGreaterThanOrEqualTo(0);
+            Assert.Contains(targetValue, new decimal[] { long.MinValue, int.MinValue, short.MinValue });
+            Assert.True(unrestrictedValue >= 0);
         }
 
         [AutoData]
@@ -270,7 +271,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(Numbers.One, Numbers.Five);
+            Assert.Contains(targetValue, new[] { Numbers.One, Numbers.Five });
         }
 
         [AutoData]
@@ -281,7 +282,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf((Numbers)100, (Numbers)200);
+            Assert.Contains(targetValue, new[] { (Numbers)100, (Numbers)200 });
         }
 
         [AutoData]
@@ -292,7 +293,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(Numbers.One | Numbers.Three, Numbers.Five);
+            Assert.Contains(targetValue, new[] { Numbers.One | Numbers.Three, Numbers.Five });
         }
 
         [InlineAutoData(10, 10)]
@@ -304,7 +305,8 @@
             // Arrange
             // Act
             // Assert
-            value.Should().Be(expectedResult).And.NotBe(int.MinValue);
+            Assert.Equal(expectedResult, value);
+            Assert.NotEqual(int.MinValue, value);
         }
 
         [MemberAutoData(nameof(MemberAutoDataOverValuesTestData))]
@@ -317,8 +319,9 @@
             // Arrange
             // Act
             // Assert
-            value.Should().Be(expectedResult).And.NotBe(int.MinValue);
-            unrestrictedValue.Should().Be(int.MinValue);
+            Assert.Equal(expectedResult, value);
+            Assert.NotEqual(int.MinValue, value);
+            Assert.Equal(int.MinValue, unrestrictedValue);
         }
 
         [AutoData]
@@ -332,8 +335,8 @@
 
             // Act
             // Assert
-            targetValues.Should().AllSatisfy(x => supported.Should().Contain(x));
-            unrestrictedValues.Should().AllSatisfy(x => x.Should().BeGreaterThanOrEqualTo(0));
+            Assert.All(targetValues, x => Assert.Contains(x, supported));
+            Assert.All(unrestrictedValues, x => Assert.True(x >= 0));
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/PickNegativeAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/PickNegativeAttributeTests.cs
@@ -6,8 +6,6 @@
     using System.Linq;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
     using global::AutoFixture.Xunit2;
@@ -79,11 +77,11 @@
             var attribute = new PickNegativeAttribute();
 
             // Act
-            Action act = () => attribute.GetCustomization(null);
+            void Act() => attribute.GetCustomization(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("parameter");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("parameter", exception.ParamName);
         }
 
         [MemberData(nameof(CustomizationUsageTestData))]
@@ -106,8 +104,8 @@
             item = (T)fixture.Create(request.Object, new SpecimenContext(fixture));
 
             // Assert
-            item.Should().BeOfType(type)
-                .And.Match(x => x.CompareTo(zero) < 0);
+            Assert.IsType(type, item);
+            Assert.True(item.CompareTo(zero) < 0);
         }
 
         [MemberData(nameof(CustomizationUsageTestData))]
@@ -129,7 +127,7 @@
             var result = (T[])fixture.Create(request.Object, new SpecimenContext(fixture));
 
             // Assert
-            result.Should().AllSatisfy(x => x.Should().BeLessThan(zero));
+            Assert.All(result, x => Assert.True(x.CompareTo(zero) < 0));
         }
 
         [InlineData(SignedByteNumbers.MinusTwo, SignedByteNumbers.MinusOne)]
@@ -154,8 +152,8 @@
             var result = (Enum)fixture.Create(request.Object, new SpecimenContext(fixture));
 
             // Assert
-            result.Should().BeOfType(type)
-                .And.BeOneOf(expectedValues);
+            Assert.IsType(type, result);
+            Assert.Contains(result, expectedValues);
         }
 
         [InlineData(SignedByteNumbers.MinusTwo, SignedByteNumbers.MinusOne)]
@@ -180,7 +178,7 @@
             var result = ((Array)fixture.Create(request.Object, new SpecimenContext(fixture))).Cast<Enum>();
 
             // Assert
-            result.Should().AllSatisfy(x => x.Should().BeOneOf(expectedValues));
+            Assert.All(result, x => Assert.Contains(x, expectedValues));
         }
 
         [AutoData]
@@ -191,7 +189,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -202,7 +200,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -213,7 +211,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -224,7 +222,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -235,7 +233,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -246,7 +244,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -257,7 +255,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeLessThan(0);
+            Assert.True(targetValue < 0);
         }
 
         [AutoData]
@@ -268,7 +266,7 @@
             // Arrange
             // Act
             // Assert
-            targetValue.Should().BeOneOf(IntNumbers.MinusOne, IntNumbers.MinusTwo);
+            Assert.Contains(targetValue, new[] { IntNumbers.MinusOne, IntNumbers.MinusTwo });
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/CheckTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/CheckTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
 
-    using FluentAssertions;
-
     using Objectivity.AutoFixture.XUnit2.Core.Common;
 
     using Xunit;
@@ -22,11 +20,11 @@
             const string expectedParameterName = "value";
 
             // Act
-            Func<object> act = () => value.NotNull(expectedParameterName);
+            static object Act() => value.NotNull(expectedParameterName);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be(expectedParameterName);
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal(expectedParameterName, exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN initialized object WHEN NotNull is invoked THEN the same object is returned")]
@@ -39,7 +37,7 @@
             var result = value.NotNull("value");
 
             // Assert
-            result.Should().Be(value);
+            Assert.Equal(value, result);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
@@ -5,8 +5,6 @@
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
-    using FluentAssertions;
-
     using global::AutoFixture.Xunit2;
 
     using Objectivity.AutoFixture.XUnit2.Core.Common;
@@ -25,11 +23,11 @@
             Type enumerableType = null;
 
             // Act
-            Func<object> act = () => enumerableType.TryGetEnumerableSingleTypeArgument(out _);
+            object Act() => enumerableType.TryGetEnumerableSingleTypeArgument(out _);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("type");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("type", exception.ParamName);
         }
 
         [InlineData(typeof(int[]), typeof(int))]
@@ -44,8 +42,8 @@
             var isSuccessful = enumerableType.TryGetEnumerableSingleTypeArgument(out var itemType);
 
             // Assert
-            isSuccessful.Should().BeTrue();
-            itemType.Should().Be(expectedType);
+            Assert.True(isSuccessful);
+            Assert.Equal(expectedType, itemType);
         }
 
         [InlineData(typeof(Tuple<int, int>))]
@@ -58,7 +56,7 @@
             var isSuccessful = enumerableType.TryGetEnumerableSingleTypeArgument(out _);
 
             // Assert
-            isSuccessful.Should().BeFalse();
+            Assert.False(isSuccessful);
         }
 
         [Fact(DisplayName = "GIVEN generic definition collection WHEN TryGetEnumerableSingleTypeArgument is invoked THEN no argument returned")]
@@ -71,7 +69,7 @@
             var isSuccessful = enumerableType.TryGetEnumerableSingleTypeArgument(out _);
 
             // Assert
-            isSuccessful.Should().BeFalse();
+            Assert.False(isSuccessful);
         }
 
         [InlineData(null, typeof(int), "items")]
@@ -84,11 +82,11 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => items.ToTypedArray(itemType);
+            object Act() => items.ToTypedArray(itemType);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be(exceptionParamName);
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal(exceptionParamName, exception.ParamName);
         }
 
         [AutoData]
@@ -102,7 +100,8 @@
             var array = items.ToTypedArray(itemType);
 
             // Assert
-            array.Should().BeEquivalentTo(items).And.Subject.GetType().IsArray.Should().BeTrue();
+            Assert.Equal(items, array);
+            Assert.True(array.GetType().IsArray);
         }
 
         [AutoData]
@@ -116,7 +115,7 @@
             var array = items.ToTypedArray(itemType);
 
             // Assert
-            array.Should().BeEquivalentTo(items);
+            Assert.Equal(items, array);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/RoundRobinEnumerableTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/RoundRobinEnumerableTests.cs
@@ -4,8 +4,6 @@
     using System.Collections;
     using System.Linq;
 
-    using FluentAssertions;
-
     using global::AutoFixture.Xunit2;
 
     using Objectivity.AutoFixture.XUnit2.Core.Common;
@@ -21,11 +19,11 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new RoundRobinEnumerable<object>(null);
+            static object Act() => new RoundRobinEnumerable<object>(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("values");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("values", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN no arguments WHEN constructor is invoked THEN exception is thrown")]
@@ -33,12 +31,13 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new RoundRobinEnumerable<object>();
+            static object Act() => new RoundRobinEnumerable<object>();
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("At least one value");
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("At least one value", exception.Message);
         }
 
         [AutoData]
@@ -50,12 +49,13 @@
             IEnumerator enumerator = new RoundRobinEnumerable<int>(values);
 
             // Act
-            Func<object> act = () => enumerator.Current;
+            object Act() => enumerator.Current;
 
             // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("initial position");
+            var exception = Assert.Throws<InvalidOperationException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("initial position", exception.Message);
         }
 
         [AutoData]
@@ -69,12 +69,13 @@
             // Act
             enumerator.MoveNext();
             enumerator.Reset();
-            Func<object> act = () => enumerator.Current;
+            object Act() => enumerator.Current;
 
             // Assert
-            act.Should().Throw<InvalidOperationException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("initial position");
+            var exception = Assert.Throws<InvalidOperationException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("initial position", exception.Message);
         }
 
         [AutoData]
@@ -94,7 +95,8 @@
             }).ToArray();
 
             // Assert
-            items.Should().AllSatisfy(x => x.Should().BeTrue()).And.HaveCount(duplicatedValues.Length);
+            Assert.All(items, Assert.True);
+            Assert.Equal(duplicatedValues.Length, items.Length);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Comparers/CustomizeAttributeComparerTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Comparers/CustomizeAttributeComparerTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Comparers
 {
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
@@ -38,7 +36,7 @@
             var result = Comparer.Compare(x, y);
 
             // Assert
-            result.Should().Be(expectedResult);
+            Assert.Equal(expectedResult, result);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/IgnoreVirtualMembersCustomizationTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/IgnoreVirtualMembersCustomizationTests.cs
@@ -23,7 +23,7 @@
             fixture.Customize(customization);
 
             // Assert
-            Assert.Multiple(fixture.ShouldIgnoreVirtualMembers);
+            fixture.ShouldIgnoreVirtualMembers();
         }
 
         [AutoData]
@@ -38,7 +38,7 @@
             fixture.Customize(customization);
 
             // Assert
-            Assert.Multiple(() => fixture.ShouldIgnoreVirtualMembers(reflectedType));
+            fixture.ShouldIgnoreVirtualMembers(reflectedType);
         }
 
         [Fact(DisplayName = "GIVEN default constructor WHEN invoked THEN reflected type should be null")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/IgnoreVirtualMembersCustomizationTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/IgnoreVirtualMembersCustomizationTests.cs
@@ -2,8 +2,6 @@
 {
     using System;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
@@ -25,7 +23,7 @@
             fixture.Customize(customization);
 
             // Assert
-            fixture.ShouldIgnoreVirtualMembers();
+            Assert.Multiple(fixture.ShouldIgnoreVirtualMembers);
         }
 
         [AutoData]
@@ -40,7 +38,7 @@
             fixture.Customize(customization);
 
             // Assert
-            fixture.ShouldIgnoreVirtualMembers(reflectedType);
+            Assert.Multiple(() => fixture.ShouldIgnoreVirtualMembers(reflectedType));
         }
 
         [Fact(DisplayName = "GIVEN default constructor WHEN invoked THEN reflected type should be null")]
@@ -51,7 +49,7 @@
             var customization = new IgnoreVirtualMembersCustomization();
 
             // Assert
-            customization.ReflectedType.Should().BeNull();
+            Assert.Null(customization.ReflectedType);
         }
 
         [AutoData]
@@ -63,7 +61,7 @@
             var customization = new IgnoreVirtualMembersCustomization(reflectedType);
 
             // Assert
-            customization.ReflectedType.Should().BeSameAs(reflectedType);
+            Assert.Same(reflectedType, customization.ReflectedType);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Factories/NegativeValuesRequestFactoryTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Factories/NegativeValuesRequestFactoryTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
 
@@ -84,11 +82,11 @@
             Type type = null;
 
             // Act
-            Action act = () => this.factory.Create(type);
+            void Act() => this.factory.Create(type);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("input");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("input", exception.ParamName);
         }
 
         [InlineData(typeof(SignedByteNumbers), SignedByteNumbers.MinusTwo, SignedByteNumbers.MinusOne)]
@@ -105,8 +103,8 @@
             var result = this.factory.Create(type);
 
             // Assert
-            result.Should().BeOfType<FixedValuesRequest>().Subject
-                .Values.Should().BeEquivalentTo(expectedValues);
+            var request = Assert.IsType<FixedValuesRequest>(result);
+            Assert.Equal(expectedValues, request.Values);
         }
 
         [MemberData(nameof(NumericTypeUsageTestData))]
@@ -121,9 +119,9 @@
             var result = this.factory.Create(type);
 
             // Assert
-            var request = result.Should().BeOfType<RangedNumberRequest>().Subject;
-            request.Minimum.Should().Be(min);
-            request.Maximum.Should().Be(max);
+            var request = Assert.IsType<RangedNumberRequest>(result);
+            Assert.Equal(min, request.Minimum);
+            Assert.Equal(max, request.Maximum);
         }
 
         [InlineData(typeof(DBNull))]
@@ -145,11 +143,13 @@
         {
             // Arrange
             // Act
-            Action act = () => this.factory.Create(type);
+            void Act() => this.factory.Create(type);
 
             // Assert
-            act.Should().Throw<ObjectCreationException>()
-                .And.Message.Should().Contain("does not accept negative values");
+            var exception = Assert.Throws<ObjectCreationException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("does not accept negative values", exception.Message);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/FixtureAssertionExtensions.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/FixtureAssertionExtensions.cs
@@ -3,42 +3,42 @@
     using System;
     using System.Linq;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
 
     using Objectivity.AutoFixture.XUnit2.Core.SpecimenBuilders;
+
+    using Xunit;
 
     internal static class FixtureAssertionExtensions
     {
         internal static void ShouldNotThrowOnRecursion(this IFixture fixture)
         {
-            // Ensure there is no behaviour for throwing exception on recursive structures.
-            fixture.Behaviors.Should().NotContain(b => b is ThrowingRecursionBehavior);
+            // Ensure there is no behavior for throwing exception on recursive structures.
+            Assert.DoesNotContain(fixture.Behaviors, b => b is ThrowingRecursionBehavior);
         }
 
         internal static void ShouldOmitRecursion(this IFixture fixture)
         {
-            // Ensure there is a behaviour added for omitting recursive types
+            // Ensure there is a behavior added for omitting recursive types
             // on default recursion depth.
-            fixture.Behaviors.Should().ContainSingle(b => b is OmitOnRecursionBehavior);
+            Assert.Single(fixture.Behaviors, b => b is OmitOnRecursionBehavior);
         }
 
         internal static void ShouldNotIgnoreVirtualMembers(this IFixture fixture)
         {
-            fixture.Customizations.Should().NotContain(s => s is IgnoreVirtualMembersSpecimenBuilder);
+            Assert.DoesNotContain(fixture.Customizations, s => s is IgnoreVirtualMembersSpecimenBuilder);
         }
 
         internal static void ShouldIgnoreVirtualMembers(this IFixture fixture)
         {
-            fixture.Customizations.Should().ContainSingle(s => s is IgnoreVirtualMembersSpecimenBuilder);
+            Assert.Single(fixture.Customizations, s => s is IgnoreVirtualMembersSpecimenBuilder);
         }
 
         internal static void ShouldIgnoreVirtualMembers(this IFixture fixture, Type reflectedType)
         {
-            fixture.Customizations.OfType<IgnoreVirtualMembersSpecimenBuilder>()
-                .Should()
-                .ContainSingle(c => c.ReflectedType == reflectedType);
+            Assert.Single(
+                fixture.Customizations.OfType<IgnoreVirtualMembersSpecimenBuilder>(),
+                c => c.ReflectedType == reflectedType);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/MemberData/MemberAutoDataItemExtenderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/MemberData/MemberAutoDataItemExtenderTests.cs
@@ -5,8 +5,6 @@
     using System.Linq;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
 
     using Moq;
@@ -51,7 +49,7 @@
             var data = noDataConverter.Extend(TestMethod, item);
 
             // Assert
-            data.Should().BeNull();
+            Assert.Null(data);
             noDataProvider.VerifyAll();
             noDataAttribute.VerifyAll();
         }
@@ -66,7 +64,7 @@
             var data = this.converter.Extend(TestMethod, item);
 
             // Assert
-            data.Should().NotBeNull();
+            Assert.NotNull(data);
             this.dataAttributeProvider.VerifyAll();
             this.dataAttribute.VerifyAll();
         }
@@ -81,7 +79,7 @@
             var data = this.converter.Extend(TestMethod, item);
 
             // Assert
-            data.Should().BeNull();
+            Assert.Null(data);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized test method WHEN Convert is invoked THEN exception is thrown")]
@@ -92,11 +90,11 @@
             var item = this.fixture.Create<object[]>();
 
             // Act
-            Func<object> act = () => this.converter.Extend(method, item);
+            object Act() => this.converter.Extend(method, item);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("testMethod");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("testMethod", exception.ParamName);
         }
 
         protected void MethodUnderTest()

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -59,7 +59,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Providers
 {
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
@@ -24,8 +22,8 @@
             var dataAttribute = provider.GetAttribute(fixture) as AutoDataAdapterAttribute;
 
             // Assert
-            dataAttribute.Should().NotBeNull();
-            dataAttribute.AdaptedFixture.Should().Be(fixture);
+            Assert.NotNull(dataAttribute);
+            Assert.Equal(fixture, dataAttribute.AdaptedFixture);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/InlineAutoDataAttributeProviderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/InlineAutoDataAttributeProviderTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Providers
 {
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
@@ -26,9 +24,9 @@
             var attribute = provider.GetAttribute(fixture, inlineValues);
 
             // Assert
-            var autoDataAdapterAttribute = attribute.Should().BeOfType<AutoDataAdapterAttribute>().Which;
-            autoDataAdapterAttribute.AdaptedFixture.Should().Be(fixture);
-            autoDataAdapterAttribute.InlineValues.Should().BeEquivalentTo(inlineValues);
+            var autoDataAdapterAttribute = Assert.IsType<AutoDataAdapterAttribute>(attribute);
+            Assert.Equal(fixture, autoDataAdapterAttribute.AdaptedFixture);
+            Assert.Equal(inlineValues, autoDataAdapterAttribute.InlineValues);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
@@ -5,8 +5,6 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
-
-    using FluentAssertions;
     using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Requests;
 
@@ -34,11 +32,11 @@
             object[] values = null;
 
             // Act
-            Func<object> act = () => new FixedValuesRequest(type, values);
+            object Act() => new FixedValuesRequest(type, values);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("operandType");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("operandType", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized values argument WHEN constructor is invoked THEN exception is thrown")]
@@ -49,11 +47,11 @@
             object[] values = null;
 
             // Act
-            Func<object> act = () => new FixedValuesRequest(type, values);
+            object Act() => new FixedValuesRequest(type, values);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("values");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("values", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN empty values argument WHEN constructor is invoked THEN exception is thrown")]
@@ -64,12 +62,13 @@
             var values = Array.Empty<object>();
 
             // Act
-            Func<object> act = () => new FixedValuesRequest(type, values);
+            object Act() => new FixedValuesRequest(type, values);
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .And.Message.Should().NotBeNullOrEmpty()
-                .And.Contain("At least one value");
+            var exception = Assert.Throws<ArgumentException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
+            Assert.Contains("At least one value", exception.Message);
         }
 
         [InlineData(typeof(int), 2)]
@@ -85,7 +84,8 @@
             var attribute = new FixedValuesRequest(type, values);
 
             // Assert
-            attribute.Values.Should().HaveCount(2).And.BeEquivalentTo(values);
+            Assert.Equal(2, attribute.Values.Count);
+            Assert.Equal(values, attribute.Values);
         }
 
         [Fact(DisplayName = "GIVEN valid arguments WHEN ToString is invoked THEN text conteins necessary information")]
@@ -97,19 +97,23 @@
             long? second = long.MinValue;
             byte? third = null;
             var attribute = new FixedValuesRequest(type, first, second, third);
+            var textParts = new[]
+            {
+                nameof(FixedValuesRequest),
+                type.Name,
+                "[Int32]",
+                $"{first.ToString(CultureInfo.InvariantCulture)},",
+                "[Int64]",
+                $"{second.Value.ToString(CultureInfo.InvariantCulture)},",
+                "[Object]",
+                "null",
+            };
 
             // Act
             var text = attribute.ToString();
 
             // Assert
-            text.Should().Contain(nameof(FixedValuesRequest))
-                .And.Contain(type.Name)
-                .And.Contain("[Int32]")
-                .And.Contain($"{first.ToString(CultureInfo.InvariantCulture)},")
-                .And.Contain("[Int64]")
-                .And.Contain($"{second.Value.ToString(CultureInfo.InvariantCulture)},")
-                .And.Contain("[Object]")
-                .And.Contain("null");
+            Assert.All(textParts, textPart => Assert.Contains(textPart, text));
         }
 
         [MemberData(nameof(ComparisonTestData))]
@@ -129,7 +133,7 @@
             var result = Equals(a, b);
 
             // Assert
-            result.Should().Be(expectedResult);
+            Assert.Equal(expectedResult, result);
         }
 
         [MemberData(nameof(ComparisonTestData))]
@@ -151,7 +155,7 @@
             var result = hashA == hashB;
 
             // Assert
-            result.Should().Be(expectedResult, $"Hash codes are different. First: {a}, HashCode: {hashA.ToString(CultureInfo.InvariantCulture)}, Second:{b}, HashCode: {hashB.ToString(CultureInfo.InvariantCulture)}");
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized request WHEN Equals is invoked THEN False is returned")]
@@ -166,7 +170,7 @@
             var result = initialized.Equals(uninitialized);
 
             // Assert
-            result.Should().BeFalse();
+            Assert.False(result);
         }
 
         [Fact(DisplayName = "GIVEN different type of object WHEN Equals is invoked THEN False is returned")]
@@ -181,7 +185,7 @@
             var result = request.Equals(differentObject);
 
             // Assert
-            result.Should().BeFalse();
+            Assert.False(result);
         }
 
         [AutoData]
@@ -200,8 +204,8 @@
             var text = fixedRequest.ToString();
 
             // Assert
-            result.Should().BeFalse();
-            text.Should().NotBeNull();
+            Assert.False(result);
+            Assert.NotNull(text);
         }
 
         [AutoData]
@@ -220,7 +224,7 @@
             var result = hashA == hashB;
 
             // Assert
-            result.Should().BeFalse();
+            Assert.False(result);
         }
 
         [InlineAutoData(typeof(ExceptValuesRequest))]
@@ -239,7 +243,7 @@
             var actualHashCode = request.GetHashCode();
 
             // Assert
-            actualHashCode.Should().Be(expectedHashCode);
+            Assert.Equal(expectedHashCode, actualHashCode);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
@@ -2,8 +2,6 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-
-    using FluentAssertions;
     using global::AutoFixture.Kernel;
     using global::AutoFixture.Xunit2;
     using Moq;
@@ -26,7 +24,7 @@
             var builder = new IgnoreVirtualMembersSpecimenBuilder();
 
             // Assert
-            builder.ReflectedType.Should().BeNull();
+            Assert.Null(builder.ReflectedType);
         }
 
         [AutoData]
@@ -38,7 +36,7 @@
             var builder = new IgnoreVirtualMembersSpecimenBuilder(reflectedType);
 
             // Assert
-            builder.ReflectedType.Should().BeSameAs(reflectedType);
+            Assert.Same(reflectedType, builder.ReflectedType);
         }
 
         [AutoData]
@@ -51,7 +49,7 @@
             var specimen = builder.Create(null, this.context);
 
             // Assert
-            specimen.Should().BeOfType<NoSpecimen>();
+            Assert.IsType<NoSpecimen>(specimen);
         }
 
         [AutoData]
@@ -64,7 +62,7 @@
             var specimen = builder.Create(new object(), this.context);
 
             // Assert
-            specimen.Should().BeOfType<NoSpecimen>();
+            Assert.IsType<NoSpecimen>(specimen);
         }
 
         [AutoData]
@@ -79,7 +77,7 @@
             var specimen = builder.Create(notVirtualPropertyInfo, this.context);
 
             // Assert
-            specimen.Should().BeOfType<NoSpecimen>();
+            Assert.IsType<NoSpecimen>(specimen);
         }
 
         [AutoData]
@@ -95,8 +93,8 @@
             var specimen = builder.Create(virtualPropertyInfo, this.context);
 
             // Assert
-            builder.ReflectedType.Should().BeSameAs(reflectedType);
-            specimen.Should().BeOfType<NoSpecimen>();
+            Assert.Same(reflectedType, builder.ReflectedType);
+            Assert.IsType<NoSpecimen>(specimen);
         }
 
         [AutoData]
@@ -111,7 +109,7 @@
             var specimen = builder.Create(virtualPropertyInfo, this.context);
 
             // Assert
-            specimen.Should().BeOfType<OmitSpecimen>();
+            Assert.IsType<OmitSpecimen>(specimen);
         }
 
         [Fact(DisplayName = "GIVEN virtual PropertyInfo request hosted in appropriate type WHEN Create is invoked THEN OmitSpecimen is returned")]
@@ -126,7 +124,7 @@
             var specimen = builder.Create(virtualPropertyInfo, this.context);
 
             // Assert
-            specimen.Should().BeOfType<OmitSpecimen>();
+            Assert.IsType<OmitSpecimen>(specimen);
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Design required by tests.")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomExceptValuesGeneratorTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomExceptValuesGeneratorTests.cs
@@ -2,8 +2,6 @@
 {
     using System;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
 
@@ -25,11 +23,11 @@
             var builder = new RandomExceptValuesGenerator();
 
             // Act
-            Func<object> act = () => builder.Create(new object(), null);
+            object Act() => builder.Create(new object(), null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("context");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("context", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized request WHEN Create is invoked THEN exception is thrown")]
@@ -40,11 +38,11 @@
             var context = new Mock<ISpecimenContext>();
 
             // Act
-            Func<object> act = () => builder.Create(null, context.Object);
+            object Act() => builder.Create(null, context.Object);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("request");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("request", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN excluded value and context which resolves to the same value WHEN Create is invoked THEN exception is thrown")]
@@ -58,11 +56,12 @@
             var request = new ExceptValuesRequest(duplicateValue.GetType(), duplicateValue);
 
             // Act
-            Func<object> act = () => builder.Create(request, context.Object);
+            object Act() => builder.Create(request, context.Object);
 
             // Assert
-            act.Should().Throw<ObjectCreationException>()
-                .And.Message.Should().NotBeNullOrEmpty();
+            var exception = Assert.Throws<ObjectCreationException>(Act);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
         }
 
         [Fact(DisplayName = "GIVEN unsupported request WHEN Create is invoked THEN NoSpecimen is returned")]
@@ -77,7 +76,8 @@
             var result = builder.Create(request, context.Object);
 
             // Assert
-            result.Should().NotBeNull().And.BeOfType<NoSpecimen>();
+            Assert.NotNull(result);
+            Assert.IsType<NoSpecimen>(result);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomFixedValuesGeneratorTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomFixedValuesGeneratorTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Linq;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
     using global::AutoFixture.Xunit2;
@@ -26,11 +24,11 @@
             var builder = new RandomFixedValuesGenerator();
 
             // Act
-            Func<object> act = () => builder.Create(new object(), null);
+            object Act() => builder.Create(new object(), null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("context");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("context", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN uninitialized request WHEN Create is invoked THEN exception is thrown")]
@@ -41,11 +39,11 @@
             var context = new Mock<ISpecimenContext>();
 
             // Act
-            Func<object> act = () => builder.Create(null, context.Object);
+            object Act() => builder.Create(null, context.Object);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("request");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("request", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN unsupported request WHEN Create is invoked THEN NoSpecimen is returned")]
@@ -60,7 +58,8 @@
             var result = builder.Create(request, context.Object);
 
             // Assert
-            result.Should().NotBeNull().And.BeOfType<NoSpecimen>();
+            Assert.NotNull(result);
+            Assert.IsType<NoSpecimen>(result);
         }
 
         [Fact(DisplayName = "GIVEN request with many values WHEN Create is invoked many times THEN only defined values are returned")]
@@ -75,9 +74,9 @@
             var result = Enumerable.Range(0, 10).Select((_) => (int)builder.Create(request, context.Object));
 
             // Assert
-            result.Should().NotBeNull()
-                .And.HaveCount(10)
-                .And.AllSatisfy(x => x.Should().BeOneOf(1, 2));
+            Assert.NotNull(result);
+            Assert.Equal(10, result.Count());
+            Assert.All(result, x => Assert.Contains(x, new[] { 1, 2 }));
         }
 
         [AutoData]
@@ -95,9 +94,9 @@
             var result = Enumerable.Range(0, 10).Select((_) => (int)builder.Create(request, context.Object));
 
             // Assert
-            result.Should().NotBeNull()
-                .And.HaveCount(10)
-                .And.AllSatisfy(x => x.Should().Be(expectedValue));
+            Assert.NotNull(result);
+            Assert.Equal(10, result.Count());
+            Assert.All(result, x => Assert.Equal(expectedValue, x));
         }
 
         [AutoData]
@@ -115,8 +114,8 @@
             var result = setup.Select(x => (int)builder.Create(x.Value, context.Object)).ToArray();
 
             // Assert
-            result.First().Should().Be(setup.First().Key);
-            result.Last().Should().Be(setup.Last().Key);
+            Assert.Equal(setup.First().Key, result.First());
+            Assert.Equal(setup.Last().Key, result.Last());
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RequestFactoryRelayTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RequestFactoryRelayTests.cs
@@ -7,8 +7,6 @@
     using System.Linq;
     using System.Reflection;
 
-    using FluentAssertions;
-
     using global::AutoFixture;
     using global::AutoFixture.Kernel;
     using global::AutoFixture.Xunit2;
@@ -28,11 +26,11 @@
         {
             // Arrange
             // Act
-            Func<object> act = () => new RequestFactoryRelay(null);
+            static object Act() => new RequestFactoryRelay(null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("requestFactory");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("requestFactory", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN empty argument WHEN Create is invoked THEN exception is thrown")]
@@ -43,11 +41,11 @@
             var builder = new RequestFactoryRelay(factory.Object);
 
             // Act
-            Func<object> act = () => builder.Create(new object(), null);
+            object Act() => builder.Create(new object(), null);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("context");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("context", exception.ParamName);
             factory.VerifyNoOtherCalls();
         }
 
@@ -60,11 +58,11 @@
             var context = new Mock<ISpecimenContext>();
 
             // Act
-            Func<object> act = () => builder.Create(null, context.Object);
+            object Act() => builder.Create(null, context.Object);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("request");
+            var exception = Assert.Throws<ArgumentNullException>(Act);
+            Assert.Equal("request", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN unsupported request type WHEN create is invoked THEN NoSpecimen is returned")]
@@ -80,7 +78,7 @@
             var result = builder.Create(request, context.Object);
 
             // Assert
-            result.Should().BeOfType<NoSpecimen>();
+            Assert.IsType<NoSpecimen>(result);
             factory.VerifyNoOtherCalls();
         }
 
@@ -103,7 +101,7 @@
             var result = builder.Create(request.Object, context.Object);
 
             // Assert
-            result.Should().BeOfType<NoSpecimen>();
+            Assert.IsType<NoSpecimen>(result);
             factory.Verify(x => x(It.IsAny<Type>()), Times.Once);
             factory.VerifyNoOtherCalls();
             context.VerifyNoOtherCalls();
@@ -133,8 +131,8 @@
             var result = builder.Create(request.Object, context.Object);
 
             // Assert
-            result.Should().NotBeNull()
-                .And.BeOfType(expectedType);
+            Assert.NotNull(result);
+            Assert.IsType(expectedType, result);
             factory.Verify(x => x(It.IsIn(expectedType)), Times.Once);
             factory.VerifyNoOtherCalls();
             context.Verify(x => x.Resolve(It.IsAny<object>()), Times.Once);
@@ -161,7 +159,7 @@
             var result = builder.Create(request.Object, context.Object);
 
             // Assert
-            result.Should().BeOfType<NoSpecimen>();
+            Assert.IsType<NoSpecimen>(result);
             factory.Verify(x => x(It.IsAny<Type>()), Times.Once);
             factory.VerifyNoOtherCalls();
             context.Verify(x => x.Resolve(It.IsAny<object>()), Times.Once);
@@ -196,9 +194,9 @@
             var result = builder.Create(request.Object, context.Object);
 
             // Assert
-            result.Should().NotBeNull()
-                .And.BeOfType(expectedType)
-                .And.Subject.As<IEnumerable>().Cast<int>().Should().NotBeEmpty();
+            Assert.NotNull(result);
+            Assert.IsType(expectedType, result);
+            Assert.NotEmpty(((IEnumerable)result).Cast<int>());
             factory.Verify(x => x(It.IsAny<Type>()), Times.Once);
             factory.VerifyNoOtherCalls();
             context.Verify(x => x.Resolve(It.IsAny<object>()), Times.Once);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated all test assertions to use xUnit's built-in assertion methods instead of FluentAssertions across multiple test classes. This change affects assertion syntax only and does not alter test logic or coverage.
- **Chores**
  - Removed FluentAssertions as a dependency from the test projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->