### PR TITLE
Use  [NoEnumeration] to prevent the false positive

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
@@ -4,8 +4,11 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+
     using global::AutoFixture.Xunit2;
+
     using JetBrains.Annotations;
+
     using Objectivity.AutoFixture.XUnit2.Core.Common;
 
     using Xunit;

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
@@ -4,9 +4,8 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-
     using global::AutoFixture.Xunit2;
-
+    using JetBrains.Annotations;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
 
     using Xunit;
@@ -76,7 +75,7 @@
         [InlineData(new[] { 1 }, null, "itemType")]
         [Theory(DisplayName = "GIVEN uninitialized argument WHEN ToTypedArray is invoked THEN exception is thrown")]
         public void GivenUninitializedArgument_WhenToTypedArrayIsInvoked_ThenExceptionIsThrown(
-            IEnumerable items,
+            [NoEnumeration] IEnumerable items,
             Type itemType,
             string exceptionParamName)
         {

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
@@ -7,8 +7,6 @@
 
     using global::AutoFixture.Xunit2;
 
-    using JetBrains.Annotations;
-
     using Objectivity.AutoFixture.XUnit2.Core.Common;
 
     using Xunit;
@@ -78,7 +76,7 @@
         [InlineData(new[] { 1 }, null, "itemType")]
         [Theory(DisplayName = "GIVEN uninitialized argument WHEN ToTypedArray is invoked THEN exception is thrown")]
         public void GivenUninitializedArgument_WhenToTypedArrayIsInvoked_ThenExceptionIsThrown(
-            [NoEnumeration] IEnumerable items,
+            IEnumerable items,
             Type itemType,
             string exceptionParamName)
         {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Common/EnumerableExtensions.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Common/EnumerableExtensions.cs
@@ -6,6 +6,8 @@
     using System.Linq;
     using System.Reflection;
 
+    using JetBrains.Annotations;
+
     internal static class EnumerableExtensions
     {
         private static readonly MethodInfo BuildTypedArrayMethodInfo =
@@ -44,7 +46,7 @@
             return false;
         }
 
-        public static object ToTypedArray(this IEnumerable items, Type itemType)
+        public static object ToTypedArray([NoEnumeration] this IEnumerable items, Type itemType)
         {
             var method = BuildTypedArrayMethodInfo.MakeGenericMethod(itemType.NotNull(nameof(itemType)));
             return method.Invoke(null, new object[] { items.NotNull(nameof(items)) });


### PR DESCRIPTION
Use  [NoEnumeration] to prevent the false positive "Possible multiple enumeration" code inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved static analysis support by adding an attribute to prevent unintended enumeration of method parameters. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->